### PR TITLE
Fix GPU OOM in dataset loading

### DIFF
--- a/clwm/data/offline_dataset.py
+++ b/clwm/data/offline_dataset.py
@@ -114,10 +114,19 @@ def read_npz_dataset(folder: str):
 
 
 @torch.no_grad()
-def load_dataset_to_gpu(folder: str):
-    """Load dataset and convert all arrays to GPU tensors."""
+def load_dataset_to_gpu(folder: str, *, batch_size: int = 2048):
+    """Load dataset and convert all arrays to GPU tensors.
+
+    Parameters
+    ----------
+    folder:
+        Path to the directory containing ``.npz`` shards.
+    batch_size:
+        Number of frames processed at once when converting them to VQ-VAE
+        indices. Reducing this value lowers peak GPU memory usage.
+    """
     frames, actions, rewards, dones = read_npz_dataset(folder)
-    ids = frames_to_indices(frames, vqvae)
+    ids = frames_to_indices(frames, vqvae, batch_size=batch_size)
     return (
         torch.tensor(ids, device=TORCH_DEVICE),
         torch.tensor(actions, device=TORCH_DEVICE),

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,8 @@ dataset:
   collect_steps: 10000
   reso: 84
   shard: 1000
+  # Number of frames processed at once when converting to VQ-VAE indices
+  load_bs: 2048
 tasks:
   train:
     - Phoenix

--- a/train.py
+++ b/train.py
@@ -406,7 +406,8 @@ if __name__ == "__main__":
             )
 
         frames_t, actions_t, rewards_t, dones_t = load_dataset_to_gpu(
-            str(game_dir)
+            str(game_dir),
+            batch_size=cfg["dataset"].get("load_bs", 2048),
         )
 
         replay = ReplayBuffer(30000)


### PR DESCRIPTION
## Summary
- process frames in manageable batches when converting to VQ‑VAE indices
- allow specifying batch size when loading datasets
- expose `load_bs` option in `config.yaml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68426b783c00832fbff624ae379ba354