### PR TITLE
Update dataset collection to use vectorized environments

### DIFF
--- a/clwm/data/__init__.py
+++ b/clwm/data/__init__.py
@@ -1,5 +1,6 @@
 from .offline_dataset import (
     gather_offline_dataset,
+    gather_datasets_parallel,
     read_npz_dataset,
     load_dataset_to_gpu,
     fill_replay_buffer,
@@ -7,6 +8,7 @@ from .offline_dataset import (
 
 __all__ = [
     "gather_offline_dataset",
+    "gather_datasets_parallel",
     "read_npz_dataset",
     "load_dataset_to_gpu",
     "fill_replay_buffer",

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,6 @@ dataset:
   shard: 1000
   # Number of frames processed at once when converting to VQ-VAE indices
   load_bs: 8192
-  num_envs: 8
 tasks:
   train:
     - SpaceInvaders


### PR DESCRIPTION
## Summary
- remove multiprocessing dataset gathering
- create parallel dataset collection using vectorized envs
- allow make_atari_vectorized_envs to accept a list of games
- update training script and config

## Testing
- `black clwm/data/offline_dataset.py clwm/data/__init__.py clwm/env/atari_envs.py train.py --line-length 79`

------
https://chatgpt.com/codex/tasks/task_e_68428be89f84832f8ea4946041067748