### PR TITLE
Add type hints and docs

### DIFF
--- a/clwm/env/atari_envs.py
+++ b/clwm/env/atari_envs.py
@@ -6,7 +6,9 @@ from ..utils.common import symlog
 gym.register_envs(ale_py)
 
 
-def wrap_reward_symlog(env):
+def wrap_reward_symlog(env: gym.Env) -> gym.Env:
+    """Return a wrapper that applies :func:`symlog` to rewards."""
+
     return TransformReward(env, lambda r: symlog(r))
 
 
@@ -17,7 +19,8 @@ def make_atari_env(
     sticky: bool = True,
     max_episode_steps: int | None = None,
     render_mode: str | None = None,
-):
+) -> gym.Env:
+    """Create a single Atari environment with symlog reward transformation."""
     base = f"ALE/{name}-v5"
     env = gym.make(
         base,
@@ -39,7 +42,13 @@ def make_atari_vectorized_envs(
     max_episode_steps: int | None = None,
     num_envs: int = 128,
     render_mode: str | None = None,
-):
+) -> gym.vector.VectorEnv:
+    """Create vectorized Atari environments.
+
+    When ``name`` is a list, each element becomes one environment in the
+    vector. The function automatically falls back to a synchronous vector
+    environment if asynchronous creation fails.
+    """
     if isinstance(name, str):
         base = f"ALE/{name}-v5"
         envs = gym.make_vec(

--- a/clwm/models/lora_layer.py
+++ b/clwm/models/lora_layer.py
@@ -4,15 +4,16 @@ import torch.nn as nn
 
 
 class LoRA(nn.Module):
-    def __init__(self, d, r=16, alpha=32):
+    """Simple Low-Rank Adaptation (LoRA) layer."""
+
+    def __init__(self, d: int, r: int = 16, alpha: int = 32) -> None:
         super().__init__()
         self.A = nn.Parameter(torch.zeros(r, d))
-        self.B = nn.Parameter(torch.empty(d, r))  # down-proj
+        self.B = nn.Parameter(torch.empty(d, r))
 
-        nn.init.kaiming_uniform_(self.B, a=math.sqrt(5))  # or .randn_ * 0.02
+        nn.init.kaiming_uniform_(self.B, a=math.sqrt(5))
 
         self.scale = alpha / r
 
-    def forward(self, x):
-        # return x @ (self.A @ self.B) * self.scale
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return (x @ self.B) @ self.A * self.scale

--- a/clwm/utils/evaluation_utils.py
+++ b/clwm/utils/evaluation_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 from ..env.atari_envs import make_atari_vectorized_envs
 from .training_utils import split_cross_entropy
-from .common import TORCH_DEVICE, ACTION_ID_START, symexp
+from .common import ACTION_ID_START, TORCH_DEVICE, symexp
 from ..models.vqvae_utils import frames_to_indices, vqvae
 
 
@@ -15,7 +15,8 @@ def build_evaluation_sequences(
     ctx: int = 32,
     n_seq: int = 128,
     num_envs: int = 128,
-):
+) -> list[torch.Tensor]:
+    """Generate context sequences for evaluation."""
     envs = make_atari_vectorized_envs(env_name, num_envs=num_envs)
     obs, _ = envs.reset(seed=123)
 
@@ -56,7 +57,8 @@ def build_evaluation_sequences(
 
 
 @torch.no_grad()
-def evaluate_on_sequences(wm, seq_batch):
+def evaluate_on_sequences(wm, seq_batch: list[torch.Tensor]) -> torch.Tensor:
+    """Return cross-entropy on a batch of evaluation sequences."""
     batch = torch.stack(seq_batch).to(TORCH_DEVICE)
     B = batch.size(0)
     inp = batch[:, :-1].reshape(B, -1)
@@ -71,7 +73,8 @@ def evaluate_on_sequences(wm, seq_batch):
 @torch.no_grad()
 def evaluate_policy(
     actor, wm, env_name: str, *, episodes: int = 128, num_envs: int = 128
-):
+) -> float:
+    """Roll out a policy and report mean score."""
     envs = make_atari_vectorized_envs(env_name, num_envs=num_envs)
     obs, _ = envs.reset(seed=0)
 

--- a/train.py
+++ b/train.py
@@ -50,11 +50,13 @@ VOCAB_SIZE = PAD_TOKEN + 1  # embedding size 147
 def left_pad_sequence(
     seq: torch.Tensor, ctx: int, pad_id: int
 ) -> torch.Tensor:
-    L = seq.size(0)
-    if L >= ctx:
+    """Left-pad ``seq`` to length ``ctx`` using ``pad_id``."""
+
+    length = seq.size(0)
+    if length >= ctx:
         return seq[-ctx:]
     pad = torch.full(
-        (ctx - L, seq.size(1)), pad_id, dtype=seq.dtype, device=seq.device
+        (ctx - length, seq.size(1)), pad_id, dtype=seq.dtype, device=seq.device
     )
     return torch.cat((pad, seq), 0)
 
@@ -79,6 +81,7 @@ def train_on_task(
     running_weights=None,
     running_fisher=None,
 ):
+    """Train world model and actor/critic on one game."""
     opt_wm = Adam(wm.parameters(), 1e-4)
     opt_act = Adam(actor.parameters(), 4e-4)
     opt_cri = Adam(critic.parameters(), 4e-4)


### PR DESCRIPTION
## Summary
- add docs and typing for Atari env helpers
- document LoRA layer
- type hint VQ-VAE modules
- document world model components
- add docs to evaluation utils
- small docs in train script

## Testing
- `black clwm/env/atari_envs.py clwm/models/lora_layer.py clwm/models/vqvae.py clwm/models/world_model.py clwm/utils/evaluation_utils.py train.py --line-length=79`
- `python train.py --config config.yaml --categories paddle --zero-shot --seed 0` *(fails: ModuleNotFoundError: No module named 'flash_attn')*

------
https://chatgpt.com/codex/tasks/task_e_6842c2382068832fbd70a9388106fdb9